### PR TITLE
Update JDK action

### DIFF
--- a/.github/workflows/microservices.yml
+++ b/.github/workflows/microservices.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Java JDK
-      uses: actions/setup-java@v1.3.0
+      uses: actions/setup-java@v1.4.3
       with:
         java-version: 11
     - name: maven-settings-xml-action


### PR DESCRIPTION
set-env has been deprecated, so updating JDK action to new version that (hopefully) doesn't use this