### PR TITLE
SITOSI: Support removing ShipmentEquipment entries

### DIFF
--- a/src/main/java/org/dcsa/ebl/repository/ShipmentEquipmentRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/ShipmentEquipmentRepository.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface ShipmentEquipmentRepository extends ExtendedRepository<ShipmentEquipment, UUID> {
     Flux<ShipmentEquipment> findAllByShipmentIDIn(List<UUID> shipmentIDs);
     Mono<ShipmentEquipment> findByEquipmentReference(String equipmentReference);
+    Mono<Void> deleteByEquipmentReferenceInAndShipmentIDIn(List<String> equipmentReferences, List<UUID> shipmentIDs);
 }

--- a/src/main/java/org/dcsa/ebl/service/ShipmentEquipmentService.java
+++ b/src/main/java/org/dcsa/ebl/service/ShipmentEquipmentService.java
@@ -11,4 +11,5 @@ import java.util.UUID;
 public interface ShipmentEquipmentService extends ExtendedBaseService<ShipmentEquipment, UUID> {
     Flux<ShipmentEquipment> findAllByShipmentIDIn(List<UUID> shipmentIDs);
     Mono<ShipmentEquipment> findByEquipmentReference(String equipmentReference);
+    Mono<Void> deleteByEquipmentReferenceInAndShipmentIDIn(List<String> equipmentReferences, List<UUID> shipmentIDs);
 }

--- a/src/main/java/org/dcsa/ebl/service/impl/ShipmentEquipmentServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/ShipmentEquipmentServiceImpl.java
@@ -36,4 +36,9 @@ public class ShipmentEquipmentServiceImpl extends ExtendedBaseServiceImpl<Shipme
     public Mono<ShipmentEquipment> findByEquipmentReference(String equipmentReference) {
         return shipmentEquipmentRepository.findByEquipmentReference(equipmentReference);
     }
+
+    @Override
+    public Mono<Void> deleteByEquipmentReferenceInAndShipmentIDIn(List<String> equipmentReferences, List<UUID> shipmentIDs) {
+        return shipmentEquipmentRepository.deleteByEquipmentReferenceInAndShipmentIDIn(equipmentReferences, shipmentIDs);
+    }
 }


### PR DESCRIPTION
If an update removes the last reference to a piece of Equipment, then
delete the ShipmentEquipment entry for it (to remove the link).

Part-of: #53
Signed-off-by: Niels Thykier <nt@asseco.dk>