### PR TITLE
Re-add support for ShippingInstruction level carrierBookingReference

### DIFF
--- a/src/main/java/org/dcsa/ebl/model/transferobjects/CargoItemTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/CargoItemTO.java
@@ -6,9 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.dcsa.ebl.model.CargoLineItem;
 import org.dcsa.ebl.model.base.AbstractCargoItem;
-import org.springframework.data.annotation.Transient;
 
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.util.List;
 
@@ -21,8 +19,7 @@ public class CargoItemTO extends AbstractCargoItem {
     @Size(max = 15)
     private String equipmentReference;
 
-    @NotNull
-    @Transient
+    @JsonInclude(JsonInclude.Include.NON_NULL)
     private String carrierBookingReference;
 
 }

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/ShippingInstructionTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/ShippingInstructionTO.java
@@ -55,7 +55,7 @@ public class ShippingInstructionTO extends AbstractShippingInstruction {
      * this ShippingInstruction and cleared from the CargoItems.
      *
      * This is useful on output to "prettify" the resulting ShippingInstruction to avoid unnecessary
-     * "per CargoItem" booking references.  The method is indempotent.
+     * "per CargoItem" booking references.  The method is idempotent.
      *
      * This is more or less the logical opposite of {@link #pushCarrierBookingReferenceIntoCargoItemsIfNecessary()}.
      *
@@ -106,7 +106,7 @@ public class ShippingInstructionTO extends AbstractShippingInstruction {
      * Pushes the carrierBookingReference to cargoItems and clears it if it is not null
      *
      * This is useful on input to "normalize" the ShippingInstruction so the code can always
-     * assume that the booking reference will appear on the cargoItems.  The method is indempotent.
+     * assume that the booking reference will appear on the cargoItems.  The method is idempotent.
      *
      * This is more or less the logical opposite of {@link #hoistCarrierBookingReferenceIfPossible()}.
      *
@@ -128,5 +128,4 @@ public class ShippingInstructionTO extends AbstractShippingInstruction {
         }
     }
 }
-
 

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/ShippingInstructionTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/ShippingInstructionTO.java
@@ -1,5 +1,6 @@
 package org.dcsa.ebl.model.transferobjects;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -12,6 +13,7 @@ import org.springframework.data.annotation.Transient;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
+import java.util.Objects;
 
 @Data
 @NoArgsConstructor
@@ -43,6 +45,88 @@ public class ShippingInstructionTO extends AbstractShippingInstruction {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private List<ShipmentLocationTO> shipmentLocations;
 
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String carrierBookingReference;
+
+    /**
+     * Pull the carrierBookingReference from cargo items into the ShippingInstruction if possible
+     *
+     * If the CargoItems all have the same carrierBookingReference, the value is moved up to the
+     * this ShippingInstruction and cleared from the CargoItems.
+     *
+     * This is useful on output to "prettify" the resulting ShippingInstruction to avoid unnecessary
+     * "per CargoItem" booking references.  The method is indempotent.
+     *
+     * This is more or less the logical opposite of {@link #pushCarrierBookingReferenceIntoCargoItemsIfNecessary()}.
+     *
+     * @throws IllegalStateException If the ShippingInstruction already has a carrierBookingReference
+     * and it is not exactly the same as it would get after this call.
+     * @throws NullPointerException If one or more CargoItemTOs had a null carrierBookingReference AND one or more
+     * of them had a non-null carrierBookingReference.  (I.e. either they all must have a carrierBookingReference
+     * or none of them can have one).
+     */
+    @JsonIgnore
+    public void hoistCarrierBookingReferenceIfPossible() {
+        String actualCentralBookingReference = this.getCarrierBookingReference();
+        String possibleCentralBookingReference = cargoItems.isEmpty() ? null : cargoItems.get(0).getCarrierBookingReference();
+        Boolean allNull = null;
+        for (CargoItemTO cargoItemTO : cargoItems) {
+            String cargoBookingReference = cargoItemTO.getCarrierBookingReference();
+            if (cargoBookingReference == null) {
+                if (allNull == Boolean.FALSE) {
+                    throw new NullPointerException("One of the CargoItemTOs had a null carrierBookingReference while another did not");
+                }
+                allNull = Boolean.TRUE;
+                continue;
+            }
+
+            if (allNull == Boolean.TRUE) {
+                throw new NullPointerException("One of the CargoItemTOs had a null carrierBookingReference while another did not");
+            }
+            allNull = Boolean.FALSE;
+            if (!cargoBookingReference.equals(possibleCentralBookingReference)) {
+                possibleCentralBookingReference = null;
+                break;
+            }
+        }
+        if (actualCentralBookingReference != null && !actualCentralBookingReference.equals(possibleCentralBookingReference)) {
+            throw new IllegalStateException("Internal error: ShippingInstruction had booking reference "
+                    + this.getCarrierBookingReference() + " but it should have been: " + actualCentralBookingReference);
+        }
+        if (possibleCentralBookingReference != null) {
+            // Hoist up the booking reference to the SI since it is the same on all items.
+            for (CargoItemTO cargoItemTO : cargoItems) {
+                cargoItemTO.setCarrierBookingReference(null);
+            }
+            this.setCarrierBookingReference(possibleCentralBookingReference);
+        }
+    }
+
+    /**
+     * Pushes the carrierBookingReference to cargoItems and clears it if it is not null
+     *
+     * This is useful on input to "normalize" the ShippingInstruction so the code can always
+     * assume that the booking reference will appear on the cargoItems.  The method is indempotent.
+     *
+     * This is more or less the logical opposite of {@link #hoistCarrierBookingReferenceIfPossible()}.
+     *
+     * @throws IllegalStateException If the ShippingInstruction and one of its CargoItem
+     * both have a non-null carrierBookingReference.
+     */
+    @JsonIgnore
+    public void pushCarrierBookingReferenceIntoCargoItemsIfNecessary() {
+        String centralBookingReference = this.getCarrierBookingReference();
+        if (centralBookingReference != null) {
+            for (CargoItemTO cargoItemTO : this.cargoItems) {
+                String cargoBookingReference = cargoItemTO.getCarrierBookingReference();
+                if (cargoBookingReference != null) {
+                    throw new IllegalStateException("CarrierBookingReference defined on SI and CargoItemTO level.");
+                }
+                cargoItemTO.setCarrierBookingReference(centralBookingReference);
+            }
+            this.setCarrierBookingReference(null);
+        }
+    }
 }
 
 


### PR DESCRIPTION
This is solved by:

 * On input, we always push down the SI level carrierBookingReference
   to the CargoItemTOs.  This way, the underlying code always work
   on the basis that CargoItemTOs /can/ have unique
   carrierBookingReferences without needing special cases for the
   SI-level varient.

 * On output, we attempt to "hoist" up the carrierBookingReference
   to the SI level as long as there is /exactly one/
   carrierBookingReference available.

Note that we are deliberately quite strict in not allowing "ambiguous"
carrierBookingReferences.  Either they are entirely on the SI level or
entirely on the CargoItemTO level.  Likewise on mapping the output, we
ensure that no CargoItemTO is "missing" a carrierBookingReference that
could affect whether we would hoist up the reference to the SI level.

Closes: #46
Signed-off-by: Niels Thykier <nt@asseco.dk>