### PR TITLE
Refactor cargo line items

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 		<springdoc.version>1.4.2</springdoc.version>
 		<rest-assured.version>4.3.1</rest-assured.version>
 		<groovy.version>3.0.2</groovy.version>
-		<dcsa.version>0.7.6-SNAPSHOT</dcsa.version>
+		<dcsa.version>0.7.7-SNAPSHOT</dcsa.version>
 		<dcsa.tag/>
 		<dcsa.artifacttype/>
 	</properties>

--- a/src/main/java/org/dcsa/ebl/ChangeSet.java
+++ b/src/main/java/org/dcsa/ebl/ChangeSet.java
@@ -45,7 +45,11 @@ public final class ChangeSet<T> {
                             + ":  The id is not among the original list of ids (null the ID field if you want to"
                             + " create a new instance)");
                 }
-                usedIds.add(updateId);
+                if (!usedIds.add(updateId)) {
+                    throw new UpdateException("Duplicate id: " + updateId
+                            + ": The entity ID was used more than once in a list where it was expected to be used"
+                            + " at most once.");
+                }
                 updatedObjects.add(update);
             } else {
                 newObjects.add(update);

--- a/src/main/java/org/dcsa/ebl/Util.java
+++ b/src/main/java/org/dcsa/ebl/Util.java
@@ -2,6 +2,8 @@ package org.dcsa.ebl;
 
 import org.dcsa.core.exception.UpdateException;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -17,6 +19,20 @@ public class Util {
      * performance issues.
      */
     public static final int SQL_LIST_BUFFER_SIZE = 70;
+
+    public static <T, I> void checkForDuplicates(Iterable<T> objects, Function<T, I> idMapper, String name) {
+        Set<I> usedIds = new HashSet<>();
+        for (T t : objects) {
+            I id = idMapper.apply(t);
+            if (id == null) {
+                continue;
+            }
+            if (!usedIds.add(id)) {
+                throw new UpdateException("Duplicate ID " + id + " (" + name + "):  The ID must occur at most once.");
+            }
+        }
+
+    }
 
     public static <T> Consumer<T> acceptAny() {
         return (t) -> {};

--- a/src/main/java/org/dcsa/ebl/model/CargoLineItem.java
+++ b/src/main/java/org/dcsa/ebl/model/CargoLineItem.java
@@ -3,28 +3,20 @@ package org.dcsa.ebl.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.dcsa.core.model.AuditBase;
-import org.dcsa.core.model.GetId;
+import org.dcsa.ebl.model.base.AbstractCargoLineItem;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 
 import java.util.UUID;
 
 @NoArgsConstructor
 @Data
-public class CargoLineItem extends AuditBase implements GetId<UUID> {
+public class CargoLineItem extends AbstractCargoLineItem {
 
     @Id
     @JsonIgnore
     private UUID id;  /* TODO: Remove */
 
-    @Column("cargo_line_item_id")
-    private String cargoLineItemID;
-
     @Column("cargo_item_id")
     private UUID cargoItemID;
-
-    @Column("shipping_marks")
-    private String shippingMarks;
 }

--- a/src/main/java/org/dcsa/ebl/model/ShipmentEquipment.java
+++ b/src/main/java/org/dcsa/ebl/model/ShipmentEquipment.java
@@ -6,6 +6,7 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.dcsa.core.model.GetId;
 import org.dcsa.ebl.model.base.AbstractShipmentEquipment;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
@@ -17,6 +18,10 @@ import java.util.UUID;
 @EqualsAndHashCode(callSuper = true)
 @NoArgsConstructor
 public class ShipmentEquipment extends AbstractShipmentEquipment implements GetId<UUID> {
+
+    @Id
+    @Column("id")
+    private UUID id;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     @Column("shipment_id")

--- a/src/main/java/org/dcsa/ebl/model/base/AbstractCargoLineItem.java
+++ b/src/main/java/org/dcsa/ebl/model/base/AbstractCargoLineItem.java
@@ -1,0 +1,17 @@
+package org.dcsa.ebl.model.base;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dcsa.core.model.AuditBase;
+import org.springframework.data.relational.core.mapping.Column;
+
+@NoArgsConstructor
+@Data
+public class AbstractCargoLineItem extends AuditBase {
+
+    @Column("cargo_line_item_id")
+    private String cargoLineItemID;
+
+    @Column("shipping_marks")
+    private String shippingMarks;
+}

--- a/src/main/java/org/dcsa/ebl/model/base/AbstractEquipment.java
+++ b/src/main/java/org/dcsa/ebl/model/base/AbstractEquipment.java
@@ -29,6 +29,9 @@ public abstract class AbstractEquipment extends AuditBase {
     @Size(max = 3)
     private WeightUnit weightUnit;
 
+    @Column("is_shipper_owned")
+    private Boolean isShipperOwned;
+
     public void setWeightUnit(String weightUnit) {
         this.weightUnit = WeightUnit.valueOf(weightUnit);
     }

--- a/src/main/java/org/dcsa/ebl/model/base/AbstractShipmentEquipment.java
+++ b/src/main/java/org/dcsa/ebl/model/base/AbstractShipmentEquipment.java
@@ -12,11 +12,6 @@ import java.util.UUID;
 @Data
 public abstract class AbstractShipmentEquipment {
 
-    @Id
-    @Column("id")
-    @JsonProperty("shipmentEquipmentID")
-    private UUID id;
-
     @Column("cargo_gross_weight")
     private Float cargoGrossWeight;
 

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/CargoItemTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/CargoItemTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.dcsa.ebl.model.CargoLineItem;
 import org.dcsa.ebl.model.base.AbstractCargoItem;
 
 import javax.validation.constraints.Size;
@@ -14,7 +13,7 @@ import java.util.List;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class CargoItemTO extends AbstractCargoItem {
-    private List<CargoLineItem> cargoLineItems;
+    private List<CargoLineItemTO> cargoLineItems;
 
     @Size(max = 15)
     private String equipmentReference;

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/CargoLineItemTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/CargoLineItemTO.java
@@ -1,0 +1,11 @@
+package org.dcsa.ebl.model.transferobjects;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dcsa.ebl.model.base.AbstractCargoLineItem;
+
+@NoArgsConstructor
+@Data
+public class CargoLineItemTO extends AbstractCargoLineItem {
+
+}

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/EquipmentTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/EquipmentTO.java
@@ -3,7 +3,13 @@ package org.dcsa.ebl.model.transferobjects;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
+import org.dcsa.ebl.model.Equipment;
 import org.dcsa.ebl.model.base.AbstractEquipment;
+import org.dcsa.ebl.model.utils.MappingUtil;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -15,6 +21,33 @@ public class EquipmentTO extends AbstractEquipment {
             EquipmentTO p = new EquipmentTO();
             p.setEquipmentReference(this.getEquipmentReference());
             return this.equals(p);
+        }
+        return false;
+    }
+
+    public Equipment createModifiedCopyOrNull(Equipment equipment) {
+        Equipment clone ;
+        boolean modified = false;
+        if (this.containsOnlyID()) {
+            return null;
+        }
+        clone = MappingUtil.instanceFrom(equipment, Equipment::new, Equipment.class);
+        assert this.getEquipmentReference().equals(equipment.getEquipmentReference());
+
+        modified |= setIfChanged(clone.getWeightUnit(), this.getWeightUnit(), clone::setWeightUnit);
+        modified |= setIfChanged(clone.getTareWeight(), this.getTareWeight(), clone::setTareWeight);
+        modified |= setIfChanged(clone.getIsoEquipmentCode(), this.getIsoEquipmentCode(), clone::setIsoEquipmentCode);
+        if (this.getIsShipperOwned() != null) {
+            modified |= setIfChanged(clone.getIsShipperOwned(), this.getIsShipperOwned(), clone::setIsShipperOwned);
+        }
+
+        return modified ? clone : null;
+    }
+
+    private static <T> boolean setIfChanged(T original, T update, Consumer<T> setter) {
+        if (!Objects.equals(original, update)) {
+            setter.accept(update);
+            return true;
         }
         return false;
     }

--- a/src/main/java/org/dcsa/ebl/model/utils/ShippingInstructionUpdateInfo.java
+++ b/src/main/java/org/dcsa/ebl/model/utils/ShippingInstructionUpdateInfo.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.NonNull;
 import org.dcsa.ebl.model.transferobjects.ShippingInstructionTO;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -16,6 +18,13 @@ public class ShippingInstructionUpdateInfo {
     private Map<String, String> equipmentReference2CarrierBookingReference;
     private Map<String, UUID> carrierBookingReference2ShipmentID;
     private Map<String, UUID> equipmentReference2ShipmentEquipmentID;
+
+    public List<UUID> getAllShipmentIDs() {
+        if (carrierBookingReference2ShipmentID == null) {
+            throw new IllegalStateException("Called too early");
+        }
+        return new ArrayList<>(carrierBookingReference2ShipmentID.values());
+    }
 
     public UUID getShipmentIDForCarrierBookingReference(@NonNull String carrierBookingReference) {
         if (carrierBookingReference2ShipmentID == null) {

--- a/src/main/java/org/dcsa/ebl/repository/CargoLineItemRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/CargoLineItemRepository.java
@@ -1,16 +1,15 @@
 package org.dcsa.ebl.repository;
 
-import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.ebl.model.CargoLineItem;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface CargoLineItemRepository extends ExtendedRepository<CargoLineItem, UUID> {
+public interface CargoLineItemRepository extends R2dbcRepository<CargoLineItem, UUID>, InsertAddonRepository<CargoLineItem> {
 
     Flux<CargoLineItem> findAllByCargoItemID(UUID cargoItemID);
     Mono<Void> deleteByCargoItemIDAndCargoLineItemIDIn(UUID cargoItemID, List<String> cargoLineItemIDs);
-    Flux<CargoLineItem> findAllByCargoItemIDAndCargoLineItemIDInOrderByCargoLineItemID(UUID cargoItemID, List<String> cargoLineItemIDs);
 }

--- a/src/main/java/org/dcsa/ebl/service/CargoLineItemService.java
+++ b/src/main/java/org/dcsa/ebl/service/CargoLineItemService.java
@@ -1,6 +1,6 @@
 package org.dcsa.ebl.service;
 
-import org.dcsa.core.service.ExtendedBaseService;
+import org.dcsa.core.service.BaseService;
 import org.dcsa.ebl.model.CargoLineItem;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
@@ -9,15 +9,12 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.UUID;
 
-public interface CargoLineItemService extends ExtendedBaseService<CargoLineItem, UUID> {
+public interface CargoLineItemService extends BaseService<CargoLineItem, UUID> {
 
     Flux<CargoLineItem> findAllByCargoItemID(UUID cargoItemID);
 
     @Transactional
     Flux<CargoLineItem> createAll(Iterable<CargoLineItem> cargoLineItems);
-
-    @Transactional
-    Flux<CargoLineItem> updateAll(Iterable<CargoLineItem> cargoLineItems);
 
     @Transactional
     Mono<Void> deleteByCargoItemIDAndCargoLineItemIDIn(UUID cargoItemID, List<String> cargoLineItemIDs);

--- a/src/main/java/org/dcsa/ebl/service/EquipmentService.java
+++ b/src/main/java/org/dcsa/ebl/service/EquipmentService.java
@@ -2,9 +2,56 @@ package org.dcsa.ebl.service;
 
 import org.dcsa.core.service.ExtendedBaseService;
 import org.dcsa.ebl.model.Equipment;
+import org.dcsa.ebl.model.transferobjects.EquipmentTO;
+import org.dcsa.ebl.model.transferobjects.ShipmentEquipmentTO;
+import org.dcsa.ebl.repository.EquipmentRepository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Mono;
 
 public interface EquipmentService extends ExtendedBaseService<Equipment, String> {
 
-    Mono<Equipment> createWithId(Equipment equipment);
+    /**
+     * Verifies and potentially updates Equipment entities to match.
+     *
+     * When the deferred Mono completes successfully, then the EquipmentTO referenced by the
+     * provided ShipmentEquipmentTO objects all exist.  Note that the EquipmentTO <i>may</i>
+     * have been replaced (via {@link ShipmentEquipmentTO#setEquipment(EquipmentTO)}) to
+     * fill in omitted information about the Equipment instances.
+     *
+     * Note that:
+     * <ul>
+     *     <li>
+     *         If a EquipmentTO consists <i>only</i> of a equipment reference ({@link EquipmentTO#containsOnlyID()}
+     *         is true), then it is <i>always</i> considered a lookup for an existing Equipment (regardless of
+     *         ownership).  In this case, the mono will signal an error if an Equipment instance with this reference
+     *         cannot be found.
+     *     </li>
+     *     <li>
+     *         If the EquipmentTO references a Carrier owned Container and {@link EquipmentTO#containsOnlyID()} is
+     *         false, then the underlying Equipment is<b>never</b> updated. If the EquipmentTO has conflicting values
+     *         for the Equipment, the Mono will signal an error.
+     *     </li>
+     *     <li>
+     *         If the EquipmentTO references a Shipper owned Container and ({@link EquipmentTO#containsOnlyID()} is
+     *         false, then {@link EquipmentTO#getIsShipperOwned()} must return TRUE (or the mono will signal an error).
+     *         Any other field is then considered an update and will be persisted in the {@link EquipmentRepository}.
+     *     </li>
+     *     <li>
+     *         If the Mono signals an error, a subset of the EquipmentTO objects on the input <i>may</i> have been
+     *         updated already and will not be undone.  The method relies on Transactions to undo persisting changes
+     *         to the underlying data store.
+     *     </li>
+     * </ul>
+     *
+     *
+     *
+     * @param shipmentEquipmentTOs ShipmentEquipmentTO objects from the request.  Note that the
+     *                             EquipmentTO object on each ShipmentEquipmentTO object <i>may</i>
+     *                             be replaced as a part of this call (e.g. to fill in omitted
+     *                             information).
+     * @return An empty mono that signals when the process is complete.
+     */
+    @Transactional(propagation = Propagation.MANDATORY)
+    Mono<Void> ensureEquipmentExistAndMatchesRequest(Iterable<ShipmentEquipmentTO> shipmentEquipmentTOs);
 }

--- a/src/main/java/org/dcsa/ebl/service/impl/EquipmentServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/EquipmentServiceImpl.java
@@ -1,11 +1,18 @@
 package org.dcsa.ebl.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.dcsa.core.exception.CreateException;
+import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.ebl.model.Equipment;
+import org.dcsa.ebl.model.base.AbstractEquipment;
+import org.dcsa.ebl.model.transferobjects.EquipmentTO;
+import org.dcsa.ebl.model.transferobjects.ShipmentEquipmentTO;
+import org.dcsa.ebl.model.utils.MappingUtil;
 import org.dcsa.ebl.repository.EquipmentRepository;
 import org.dcsa.ebl.service.EquipmentService;
 import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @RequiredArgsConstructor
@@ -25,7 +32,46 @@ public class EquipmentServiceImpl extends ExtendedBaseServiceImpl<EquipmentRepos
     }
 
     @Override
-    public Mono<Equipment> createWithId(Equipment equipment) {
-        return equipmentRepository.insert(equipment);
+    public Mono<Void> ensureEquipmentExistAndMatchesRequest(Iterable<ShipmentEquipmentTO> shipmentEquipmentTOs) {
+        return Flux.fromIterable(shipmentEquipmentTOs)
+                .flatMap(shipmentEquipmentTO -> {
+                    EquipmentTO equipmentTO = shipmentEquipmentTO.getEquipment();
+                    String equipmentReference = equipmentTO.getEquipmentReference();
+                    return equipmentRepository.findById(equipmentReference)
+                            .flatMap(resolvedEquipment -> {
+                                Equipment updatedVersion = equipmentTO.createModifiedCopyOrNull(resolvedEquipment);
+                                if (updatedVersion != null) {
+                                    if (!resolvedEquipment.getIsShipperOwned()) {
+                                        return Mono.error(new UpdateException("Cannot modify Carrier owned Equipment (via reference): " + equipmentReference));
+                                    }
+                                    if (!Boolean.TRUE.equals(updatedVersion.getIsShipperOwned())) {
+                                        return Mono.error(new UpdateException("Cannot turn Shipper owner Equipment "
+                                                + equipmentReference + " into a Carrier owned Equipment"
+                                                + " (\"isShipperOwned\" must be true)"
+                                        ));
+                                    }
+                                    return preUpdateHook(resolvedEquipment, updatedVersion)
+                                            .flatMap(this::save);
+                                }
+                                return Mono.just(resolvedEquipment);
+                            }).switchIfEmpty(Mono.defer(() -> {
+                                Equipment equipment;
+                                if (equipmentTO.containsOnlyID()) {
+                                    return Mono.error(new CreateException("Unknown Equipment reference: " + equipmentReference));
+                                }
+                                if (!Boolean.TRUE.equals(equipmentTO.getIsShipperOwned())) {
+                                    return Mono.error(new CreateException("Unknown Equipment reference: " + equipmentReference
+                                            + " (set \"isShipperOwned\" to true to create it if it is your own container)"));
+                                }
+                                equipment = MappingUtil.instanceFrom(equipmentTO, Equipment::new, AbstractEquipment.class);
+                                equipment.setIsShipperOwned(Boolean.TRUE);
+                                return equipmentRepository.insert(equipment);
+                            })).zipWith(Mono.just(shipmentEquipmentTO));
+                }).doOnNext(tuple -> {
+                    Equipment equipment = tuple.getT1();
+                    ShipmentEquipmentTO shipmentEquipmentTO = tuple.getT2();
+                    EquipmentTO newEquipmentTO = MappingUtil.instanceFrom(equipment, EquipmentTO::new, AbstractEquipment.class);
+                    shipmentEquipmentTO.setEquipment(newEquipmentTO);
+                }).then();
     }
 }

--- a/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionTOServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionTOServiceImpl.java
@@ -585,7 +585,14 @@ public class ShippingInstructionTOServiceImpl implements ShippingInstructionTOSe
                                 )
                         )
                     );
-        }).then(Mono.just(shippingInstructionTO));
+        }).then(Mono.just(shippingInstructionTO))
+        // Conclude with a lookup from scratch.  It may seem wasteful it is the
+        // Simplest way to get this correct as we can get additional information
+        // that were not a part of the POST (e.g. ShipmentLocations via the
+        // Shipment).  See #63 and #64 as an example of issues fixed by this
+        // approach
+        .map(ShippingInstructionTO::getId)
+        .flatMap(this::findById);
     }
 
     @Transactional

--- a/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionTOServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionTOServiceImpl.java
@@ -637,6 +637,19 @@ public class ShippingInstructionTOServiceImpl implements ShippingInstructionTOSe
                                 + " identical) OR place them entirely on the CargoItem level (if you need distinct values)."
                         ));
                     }
+
+                    checkForDuplicates(update.getCargoItems(), CargoItemTO::getId, "cargoItems[*].cargoItemID");
+                    for (CargoItemTO cargoItemTO : update.getCargoItems()) {
+                        UUID id = cargoItemTO.getId();
+                        String name = id != null ? "found in cargoItem with id " + id.toString() : "found in cargoItem without an id";
+                        checkForDuplicates(cargoItemTO.getCargoLineItems(), CargoLineItem::getId, name);
+                    }
+                    checkForDuplicates(
+                            update.getShipmentEquipments(),
+                            se -> se.getEquipment().getEquipmentReference(),
+                            "shipmentLocations[*].equipment.equipmentReference"
+                    );
+
                     ShippingInstructionUpdateInfo shippingInstructionUpdateInfo = new ShippingInstructionUpdateInfo(shippingInstructionId, update);
                     ShippingInstruction updatedModel = MappingUtil.instanceFrom(
                             update,


### PR DESCRIPTION
Rewrite handling of CargoItem and CargoLineItem

In particular, remove `cargoItemID` from `CargoLineItemTO` as it is
not present in the swagger spec. This in turn fixes two issues (one
directly, one from the relevant refactoring to support the change).

Closes: #62
Closes: #65
Signed-off-by: Niels Thykier <nt@asseco.dk>