### PR TITLE
Rewrite handling of CargoItem and CargoLineItem

### DIFF
--- a/src/main/java/org/dcsa/ebl/model/CargoLineItem.java
+++ b/src/main/java/org/dcsa/ebl/model/CargoLineItem.java
@@ -3,28 +3,20 @@ package org.dcsa.ebl.model;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.dcsa.core.model.AuditBase;
-import org.dcsa.core.model.GetId;
+import org.dcsa.ebl.model.base.AbstractCargoLineItem;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Transient;
 import org.springframework.data.relational.core.mapping.Column;
 
 import java.util.UUID;
 
 @NoArgsConstructor
 @Data
-public class CargoLineItem extends AuditBase implements GetId<UUID> {
+public class CargoLineItem extends AbstractCargoLineItem {
 
     @Id
     @JsonIgnore
     private UUID id;  /* TODO: Remove */
 
-    @Column("cargo_line_item_id")
-    private String cargoLineItemID;
-
     @Column("cargo_item_id")
     private UUID cargoItemID;
-
-    @Column("shipping_marks")
-    private String shippingMarks;
 }

--- a/src/main/java/org/dcsa/ebl/model/base/AbstractCargoLineItem.java
+++ b/src/main/java/org/dcsa/ebl/model/base/AbstractCargoLineItem.java
@@ -1,0 +1,17 @@
+package org.dcsa.ebl.model.base;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dcsa.core.model.AuditBase;
+import org.springframework.data.relational.core.mapping.Column;
+
+@NoArgsConstructor
+@Data
+public class AbstractCargoLineItem extends AuditBase {
+
+    @Column("cargo_line_item_id")
+    private String cargoLineItemID;
+
+    @Column("shipping_marks")
+    private String shippingMarks;
+}

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/CargoItemTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/CargoItemTO.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
-import org.dcsa.ebl.model.CargoLineItem;
 import org.dcsa.ebl.model.base.AbstractCargoItem;
 
 import javax.validation.constraints.Size;
@@ -14,7 +13,7 @@ import java.util.List;
 @Data
 @EqualsAndHashCode(callSuper = true)
 public class CargoItemTO extends AbstractCargoItem {
-    private List<CargoLineItem> cargoLineItems;
+    private List<CargoLineItemTO> cargoLineItems;
 
     @Size(max = 15)
     private String equipmentReference;

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/CargoLineItemTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/CargoLineItemTO.java
@@ -1,0 +1,11 @@
+package org.dcsa.ebl.model.transferobjects;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dcsa.ebl.model.base.AbstractCargoLineItem;
+
+@NoArgsConstructor
+@Data
+public class CargoLineItemTO extends AbstractCargoLineItem {
+
+}

--- a/src/main/java/org/dcsa/ebl/model/utils/ShippingInstructionUpdateInfo.java
+++ b/src/main/java/org/dcsa/ebl/model/utils/ShippingInstructionUpdateInfo.java
@@ -4,6 +4,8 @@ import lombok.Data;
 import lombok.NonNull;
 import org.dcsa.ebl.model.transferobjects.ShippingInstructionTO;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -16,6 +18,13 @@ public class ShippingInstructionUpdateInfo {
     private Map<String, String> equipmentReference2CarrierBookingReference;
     private Map<String, UUID> carrierBookingReference2ShipmentID;
     private Map<String, UUID> equipmentReference2ShipmentEquipmentID;
+
+    public List<UUID> getAllShipmentIDs() {
+        if (carrierBookingReference2ShipmentID == null) {
+            throw new IllegalStateException("Called too early");
+        }
+        return new ArrayList<>(carrierBookingReference2ShipmentID.values());
+    }
 
     public UUID getShipmentIDForCarrierBookingReference(@NonNull String carrierBookingReference) {
         if (carrierBookingReference2ShipmentID == null) {

--- a/src/main/java/org/dcsa/ebl/repository/CargoLineItemRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/CargoLineItemRepository.java
@@ -1,16 +1,15 @@
 package org.dcsa.ebl.repository;
 
-import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.ebl.model.CargoLineItem;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.List;
 import java.util.UUID;
 
-public interface CargoLineItemRepository extends ExtendedRepository<CargoLineItem, UUID> {
+public interface CargoLineItemRepository extends R2dbcRepository<CargoLineItem, UUID>, InsertAddonRepository<CargoLineItem> {
 
     Flux<CargoLineItem> findAllByCargoItemID(UUID cargoItemID);
     Mono<Void> deleteByCargoItemIDAndCargoLineItemIDIn(UUID cargoItemID, List<String> cargoLineItemIDs);
-    Flux<CargoLineItem> findAllByCargoItemIDAndCargoLineItemIDInOrderByCargoLineItemID(UUID cargoItemID, List<String> cargoLineItemIDs);
 }

--- a/src/main/java/org/dcsa/ebl/service/CargoLineItemService.java
+++ b/src/main/java/org/dcsa/ebl/service/CargoLineItemService.java
@@ -1,6 +1,6 @@
 package org.dcsa.ebl.service;
 
-import org.dcsa.core.service.ExtendedBaseService;
+import org.dcsa.core.service.BaseService;
 import org.dcsa.ebl.model.CargoLineItem;
 import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
@@ -9,15 +9,12 @@ import reactor.core.publisher.Mono;
 import java.util.List;
 import java.util.UUID;
 
-public interface CargoLineItemService extends ExtendedBaseService<CargoLineItem, UUID> {
+public interface CargoLineItemService extends BaseService<CargoLineItem, UUID> {
 
     Flux<CargoLineItem> findAllByCargoItemID(UUID cargoItemID);
 
     @Transactional
     Flux<CargoLineItem> createAll(Iterable<CargoLineItem> cargoLineItems);
-
-    @Transactional
-    Flux<CargoLineItem> updateAll(Iterable<CargoLineItem> cargoLineItems);
 
     @Transactional
     Mono<Void> deleteByCargoItemIDAndCargoLineItemIDIn(UUID cargoItemID, List<String> cargoLineItemIDs);


### PR DESCRIPTION
In particular, remove `cargoItemID` from `CargoLineItemTO` as it is
not present in the swagger spec. This in turn fixes two issues (one
directly, one from the relevant refactoring to support the change).

Closes: #62
Closes: #65
Signed-off-by: Niels Thykier <nt@asseco.dk>