### PR TITLE
Remove ShipmentLocation and Location handling from SI

### DIFF
--- a/src/main/java/org/dcsa/ebl/model/transferobjects/ShippingInstructionTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/ShippingInstructionTO.java
@@ -6,14 +6,12 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.dcsa.ebl.model.Reference;
-import org.dcsa.ebl.model.ShipmentLocationTO;
 import org.dcsa.ebl.model.base.AbstractShippingInstruction;
 import org.springframework.data.annotation.Transient;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.List;
-import java.util.Objects;
 
 @Data
 @NoArgsConstructor
@@ -39,11 +37,6 @@ public class ShippingInstructionTO extends AbstractShippingInstruction {
     @Transient
     @Valid
     private List<DocumentPartyTO> documentParties;
-
-    @NotNull
-    @Transient
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    private List<ShipmentLocationTO> shipmentLocations;
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private String carrierBookingReference;

--- a/src/main/java/org/dcsa/ebl/repository/ShipmentLocationRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/ShipmentLocationRepository.java
@@ -2,20 +2,9 @@ package org.dcsa.ebl.repository;
 
 import org.dcsa.core.repository.ExtendedRepository;
 import org.dcsa.ebl.model.ShipmentLocation;
-import org.dcsa.ebl.model.enums.ShipmentLocationType;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.UUID;
 
-public interface ShipmentLocationRepository extends ExtendedRepository<ShipmentLocation, UUID> {
+public interface ShipmentLocationRepository extends ExtendedRepository<ShipmentLocation, UUID>, InsertAddonRepository<ShipmentLocation> {
 
-    Flux<ShipmentLocation> findAllByShipmentIDIn(List<UUID> shipmentIDs);
-
-    Flux<ShipmentLocation> findByLocationTypeAndLocationIDAndShipmentIDIn(
-                                                                         ShipmentLocationType shipmentLocationType,
-                                                                         UUID locationID,
-                                                                         List<UUID> shipmentIDs
-                                                                        );
 }

--- a/src/main/java/org/dcsa/ebl/service/ShipmentLocationService.java
+++ b/src/main/java/org/dcsa/ebl/service/ShipmentLocationService.java
@@ -2,28 +2,9 @@ package org.dcsa.ebl.service;
 
 import org.dcsa.core.service.ExtendedBaseService;
 import org.dcsa.ebl.model.ShipmentLocation;
-import org.dcsa.ebl.model.ShipmentLocationTO;
-import org.dcsa.ebl.model.enums.ShipmentLocationType;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
 
-import java.util.List;
 import java.util.UUID;
-import java.util.function.BiFunction;
 
 public interface ShipmentLocationService extends ExtendedBaseService<ShipmentLocation, UUID> {
-    Flux<ShipmentLocation> createAll(Flux<ShipmentLocation> shipmentLocations);
-    Flux<ShipmentLocation> findAllByShipmentIDIn(List<UUID> shipmentIDs);
 
-    Mono<Void> updateAllRelatedFromTO(
-            List<UUID> shipmentIDs,
-            Iterable<ShipmentLocationTO> shipmentLocationTOs,
-            BiFunction<ShipmentLocation, ShipmentLocationTO, Mono<ShipmentLocation>> mutator
-    );
-
-    Flux<ShipmentLocation> findByLocationTypeAndLocationIDAndShipmentIDIn(
-                                                                          ShipmentLocationType shipmentLocationType,
-                                                                          UUID locationID,
-                                                                          List<UUID> shipmentID
-    );
 }

--- a/src/main/java/org/dcsa/ebl/service/impl/ShipmentLocationServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/ShipmentLocationServiceImpl.java
@@ -1,25 +1,14 @@
 package org.dcsa.ebl.service.impl;
 
 import lombok.RequiredArgsConstructor;
-import org.dcsa.core.exception.UpdateException;
 import org.dcsa.core.service.impl.ExtendedBaseServiceImpl;
 import org.dcsa.ebl.model.ShipmentLocation;
-import org.dcsa.ebl.model.ShipmentLocationTO;
-import org.dcsa.ebl.model.enums.ShipmentLocationType;
-import org.dcsa.ebl.model.utils.MappingUtil;
 import org.dcsa.ebl.repository.ShipmentLocationRepository;
 import org.dcsa.ebl.service.ShipmentLocationService;
 import org.springframework.stereotype.Service;
-import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
-import java.util.function.BiFunction;
-
-import static org.dcsa.ebl.Util.SQL_LIST_BUFFER_SIZE;
 
 @RequiredArgsConstructor
 @Service
@@ -42,92 +31,8 @@ public class ShipmentLocationServiceImpl extends ExtendedBaseServiceImpl<Shipmen
         return Mono.error(new UnsupportedOperationException("findById not supported"));
     }
 
-    protected Mono<ShipmentLocation> preUpdateHook(ShipmentLocation current, ShipmentLocation update) {
-        // FIXME: Revise this when we get compound Id support figured out
-        // NB: We rely on this control check in the updateAll method
-        if (! current.getShipmentID().equals(update.getShipmentID())) {
-            return Mono.error(new UpdateException("update called with a non-matching item!"));
-        }
-        if (! current.getLocationID().equals(update.getLocationID())) {
-            return Mono.error(new UpdateException("update called with a non-matching item!"));
-        }
-        if (! current.getLocationType().equals(update.getLocationType())) {
-            return Mono.error(new UpdateException("update called with a non-matching item!"));
-        }
-        update.setId(current.getId());
-        return super.preUpdateHook(current, update);
-    }
-
     @Override
     public Mono<ShipmentLocation> update(ShipmentLocation update) {
-        return shipmentLocationRepository.findByLocationTypeAndLocationIDAndShipmentIDIn(
-                update.getLocationType(),
-                update.getLocationID(),
-                Collections.singletonList(update.getShipmentID())
-        ).single()  // There must be exactly one match.
-         .onErrorMap(NoSuchElementException.class, error -> new UpdateException("Cannot create ShipmentLocation via update ("
-                 + update.getLocationType() + ", " + update.getLocationID() + ")"))
-         .flatMap(current -> this.preUpdateHook(current, update))
-         .flatMap(this::save);
-    }
-
-    public Mono<Void> updateAllRelatedFromTO(
-            List<UUID> shipmentIDs,
-            Iterable<ShipmentLocationTO> shipmentLocationTOs,
-            BiFunction<ShipmentLocation, ShipmentLocationTO, Mono<ShipmentLocation>> mutator) {
-        return Flux.fromIterable(shipmentLocationTOs)
-                // FIXME: 1-N performance issue.  Slightly mitigated by shipmentIDs but it is still one
-                // query per "location ID, location Type".
-                .concatMap(shipmentLocationTO ->
-                        Mono.zip(
-                                Mono.just(shipmentLocationTO),
-                                shipmentLocationRepository.findByLocationTypeAndLocationIDAndShipmentIDIn(
-                                        shipmentLocationTO.getLocationType(),
-                                        shipmentLocationTO.getLocationID(),
-                                        shipmentIDs
-                                ).collectList()
-                        )
-                ).concatMap(tuple -> {
-                    ShipmentLocationTO shipmentLocationTO = tuple.getT1();
-                    List<ShipmentLocation> originals = tuple.getT2();
-                    if (originals.size() != shipmentIDs.size()) {
-                        return Flux.error(new IllegalStateException("Got " + originals.size()
-                                + " ShipmentLocations but expected " + shipmentIDs.size() + " for location type "
-                                + shipmentLocationTO.getLocationType() + " and location id "
-                                + shipmentLocationTO.getLocationID()));
-                    }
-
-                    return Flux.fromIterable(originals).concatMap(original -> {
-                        ShipmentLocation update = MappingUtil.instanceFrom(original, ShipmentLocation::new, ShipmentLocation.class);
-                        return Mono.zip(
-                                Mono.just(original),
-                                mutator.apply(update, shipmentLocationTO)
-                        );
-                    });
-                })
-                .concatMap(tuple -> preUpdateHook(tuple.getT1(), tuple.getT2()))
-                .concatMap(this::preSaveHook)
-                .buffer(SQL_LIST_BUFFER_SIZE)
-                .concatMap(shipmentLocationRepository::saveAll)
-                .then();
-    }
-
-    @Override
-    public Flux<ShipmentLocation> createAll(Flux<ShipmentLocation> shipmentLocations) {
-        return shipmentLocations
-                .concatMap(this::preCreateHook)
-                .concatMap(this::preSaveHook)
-                .buffer(SQL_LIST_BUFFER_SIZE)
-                .concatMap(shipmentLocationRepository::saveAll);
-    }
-
-    @Override
-    public Flux<ShipmentLocation> findAllByShipmentIDIn(List<UUID> shipmentIDs) {
-        return shipmentLocationRepository.findAllByShipmentIDIn(shipmentIDs);
-    }
-
-    @Override
-    public Flux<ShipmentLocation> findByLocationTypeAndLocationIDAndShipmentIDIn(ShipmentLocationType shipmentLocationType, UUID locationID, List<UUID> shipmentIDs) {
-        return shipmentLocationRepository.findByLocationTypeAndLocationIDAndShipmentIDIn(shipmentLocationType, locationID, shipmentIDs);
+        return Mono.error(new UnsupportedOperationException("update not supported"));
     }
 }


### PR DESCRIPTION
We no longer allow updates to ShipmentLocation via POST/PUT SI and we
no longer expose ShipmentLocation via the SI either.

Closes: #42
Signed-off-by: Niels Thykier <nt@asseco.dk>