### PR TITLE
Tolerate DisplayedAddress and PartyContactDetails attributes

### DIFF
--- a/.github/workflows/microservices.yml
+++ b/.github/workflows/microservices.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: dcsaorg/DCSA-Information-Model
-        ref: master
+        ref: document-party-updates
         path: DCSA-Information-Model
 
     - name: Run the EBL microservice plus database

--- a/src/main/java/org/dcsa/ebl/model/DisplayedAddress.java
+++ b/src/main/java/org/dcsa/ebl/model/DisplayedAddress.java
@@ -1,0 +1,42 @@
+package org.dcsa.ebl.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.dcsa.core.model.GetId;
+import org.dcsa.ebl.model.enums.PartyFunction;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.util.UUID;
+
+@Table("displayed_address")
+@Data
+public class DisplayedAddress implements GetId<UUID> {
+
+    @Id
+    @JsonIgnore
+    private UUID id;  /* TODO: Remove */
+
+    @Column("party_id")
+    private UUID partyID;
+
+    @Column("party_function")
+    private PartyFunction partyFunction;
+
+    @Column("shipping_instruction_id")
+    private UUID shippingInstructionID;
+
+    @Column("shipment_id")
+    private UUID shipmentID;
+
+    @Column("address_line")
+    @Size(max=250)
+    private String addressLine;
+
+    @NotNull
+    @Column("address_line_number")
+    private Integer addressLineNumber;
+}

--- a/src/main/java/org/dcsa/ebl/model/DocumentParty.java
+++ b/src/main/java/org/dcsa/ebl/model/DocumentParty.java
@@ -28,4 +28,7 @@ public class DocumentParty extends AbstractDocumentParty implements GetId<UUID> 
 
     @Column("shipment_id")
     private UUID shipmentID;
+
+    @Column("party_contact_details_id")
+    private UUID partyContactDetailsID;
 }

--- a/src/main/java/org/dcsa/ebl/model/Party.java
+++ b/src/main/java/org/dcsa/ebl/model/Party.java
@@ -1,22 +1,16 @@
 package org.dcsa.ebl.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import org.dcsa.core.model.GetId;
-import org.dcsa.ebl.Util;
-import org.dcsa.ebl.model.base.AbstractLocation;
 import org.dcsa.ebl.model.base.AbstractParty;
-import org.dcsa.ebl.model.transferobjects.ModelReferencingTO;
 import org.dcsa.ebl.model.transferobjects.PartyTO;
 import org.dcsa.ebl.model.transferobjects.SetId;
 import org.dcsa.ebl.model.utils.MappingUtil;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Table;
 
-import javax.validation.constraints.Size;
 import java.util.Objects;
 import java.util.UUID;
 

--- a/src/main/java/org/dcsa/ebl/model/PartyContactDetails.java
+++ b/src/main/java/org/dcsa/ebl/model/PartyContactDetails.java
@@ -1,0 +1,28 @@
+package org.dcsa.ebl.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Data;
+import org.dcsa.core.model.GetId;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+import javax.validation.constraints.Email;
+import java.util.UUID;
+
+@Table("party_contact_details")
+@Data
+public class PartyContactDetails implements GetId<UUID> {
+
+    @Id
+    @JsonIgnore
+    private UUID id;
+
+    private String name;
+
+    private String phone;
+
+    @Email
+    private String email;
+
+    private String fax;
+}

--- a/src/main/java/org/dcsa/ebl/model/base/AbstractDocumentParty.java
+++ b/src/main/java/org/dcsa/ebl/model/base/AbstractDocumentParty.java
@@ -26,14 +26,6 @@ public class AbstractDocumentParty extends AuditBase {
         this.partyFunction = partyFunction;
     }
 
-    @Column("displayed_address")
-    @Size(max = 250)
-    private String displayedAddress;
-
-    @Column("party_contact_details")
-    @Size(max = 250)
-    private String partyContactDetails;
-
     @Column("should_be_notified")
     private Boolean shouldBeNotified;
 }

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/DocumentPartyTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/DocumentPartyTO.java
@@ -3,9 +3,11 @@ package org.dcsa.ebl.model.transferobjects;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import org.dcsa.ebl.model.Party;
+import org.dcsa.ebl.model.PartyContactDetails;
 import org.dcsa.ebl.model.base.AbstractDocumentParty;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -13,4 +15,8 @@ public class DocumentPartyTO extends AbstractDocumentParty {
 
     @NotNull
     private PartyTO party;
+
+    private PartyContactDetails partyContactDetails;
+
+    private List<String> displayedAddress;
 }

--- a/src/main/java/org/dcsa/ebl/model/transferobjects/PartyTO.java
+++ b/src/main/java/org/dcsa/ebl/model/transferobjects/PartyTO.java
@@ -20,8 +20,6 @@ public class PartyTO extends AbstractParty implements ModelReferencingTO<Party, 
 
     private Address address;
 
-    private UUID addressID;
-
     @Override
     public boolean isSolelyReferenceToModel() {
         return Util.containsOnlyID(this, PartyTO::new);

--- a/src/main/java/org/dcsa/ebl/repository/DisplayedAddressRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/DisplayedAddressRepository.java
@@ -1,0 +1,22 @@
+package org.dcsa.ebl.repository;
+
+import org.dcsa.core.repository.ExtendedRepository;
+import org.dcsa.ebl.model.DisplayedAddress;
+import org.springframework.data.r2dbc.repository.Modifying;
+import org.springframework.data.r2dbc.repository.Query;
+import reactor.core.publisher.Mono;
+
+import java.util.UUID;
+
+public interface DisplayedAddressRepository extends ExtendedRepository<DisplayedAddress, UUID> {
+
+    @Modifying
+    @Query("UPDATE displayed_address SET shipping_instruction_id = NULL"
+            + " WHERE shipping_instruction_id = :shippingInstructionID"
+            + "   AND shipment_id IS NOT NULL"
+    )
+    Mono<Integer> clearShippingInstructionIDWhereShipmentIDIsNotNull(UUID shippingInstructionID);
+
+
+    Mono<Void> deleteByShippingInstructionIDAndShipmentIDIsNotNull(UUID shippingInstructionID);
+}

--- a/src/main/java/org/dcsa/ebl/repository/DocumentPartyRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/DocumentPartyRepository.java
@@ -10,6 +10,10 @@ import java.util.UUID;
 
 public interface DocumentPartyRepository extends ExtendedRepository<DocumentParty, UUID> {
     Flux<DocumentParty> findAllByShippingInstructionID(UUID shippingInstructionID);
-    Mono<DocumentParty> findByPartyIDAndPartyFunction(UUID partyID, PartyFunction partyFunction);
-    Mono<Integer> deleteByPartyIDAndPartyFunctionAndShipmentID(UUID partyID, PartyFunction partyFunction, UUID shipmentID);
+    Mono<DocumentParty> findByPartyIDAndPartyFunctionAndShippingInstructionIDAndShipmentID(
+            UUID partyID,
+            PartyFunction partyFunction,
+            UUID shippingInstructionID,
+            UUID shipmentID
+    );
 }

--- a/src/main/java/org/dcsa/ebl/repository/PartyContactDetailsRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/PartyContactDetailsRepository.java
@@ -1,0 +1,10 @@
+package org.dcsa.ebl.repository;
+
+import org.dcsa.core.repository.ExtendedRepository;
+import org.dcsa.ebl.model.PartyContactDetails;
+
+import java.util.UUID;
+
+public interface PartyContactDetailsRepository extends ExtendedRepository<PartyContactDetails, UUID> {
+
+}

--- a/src/main/java/org/dcsa/ebl/service/DocumentPartyService.java
+++ b/src/main/java/org/dcsa/ebl/service/DocumentPartyService.java
@@ -2,7 +2,6 @@ package org.dcsa.ebl.service;
 
 import org.dcsa.core.service.ExtendedBaseService;
 import org.dcsa.ebl.model.DocumentParty;
-import org.dcsa.ebl.model.enums.PartyFunction;
 import org.dcsa.ebl.model.transferobjects.DocumentPartyTO;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -11,7 +10,5 @@ import java.util.UUID;
 
 public interface DocumentPartyService extends ExtendedBaseService<DocumentParty, UUID> {
     Flux<DocumentParty> findAllByShippingInstructionID(UUID shippingInstructionID);
-    Mono<DocumentParty> findByPartyIDAndPartyFunction(UUID partyID, PartyFunction partyFunction);
-    Mono<Integer> deleteByPartyIDAndPartyFunctionAndShipmentID(UUID partyID, PartyFunction partyFunction, UUID shipmentID);
-    Mono<Void> deleteObsoleteDocumentPartyInstances(Iterable<DocumentPartyTO> documentPartyTOs);
+    Mono<Void> deleteObsoleteDocumentPartyInstances(UUID shippingInstructionID);
 }


### PR DESCRIPTION
With these changes, EBL will now accept but ignore the DisplayedAddress and PartyContactDetails (both via REST api endpoints and the relevant SQL changes in the database).  That will come in a future commit.

Currently, all work with these entities have been isolated in the DocumentPartyService and for now they do not have their own service.