### PR TITLE
SI: Make callbackURL optional and add isChargesDisplayed

### DIFF
--- a/src/main/java/org/dcsa/ebl/model/base/AbstractShippingInstruction.java
+++ b/src/main/java/org/dcsa/ebl/model/base/AbstractShippingInstruction.java
@@ -49,7 +49,8 @@ public abstract class AbstractShippingInstruction extends AuditBase implements G
     }
 
     @Column("callback_url")
-    @NotNull
     private String callbackUrl;
 
+    @Column("is_charges_displayed")
+    private Boolean isChargesDisplayed = Boolean.FALSE;
 }


### PR DESCRIPTION
Temporarily set `isChargesDisplayed` by default to cope with the API
validator not knowing about it yet (it cannot before this is merged
and the database has it as a required field, so we have to break the
chicken vs. egg cycle somewhere).

Signed-off-by: Niels Thykier <nt@asseco.dk>