### PR TITLE
DDT-965: Support admendmentToTransportDocument on SIs

### DIFF
--- a/src/main/java/org/dcsa/ebl/repository/ShippingInstructionRepository.java
+++ b/src/main/java/org/dcsa/ebl/repository/ShippingInstructionRepository.java
@@ -39,6 +39,12 @@ public interface ShippingInstructionRepository
   Mono<Boolean> setDocumentStatusByID(
       ShipmentEventTypeCode documentStatus, OffsetDateTime updatedDateTime, String id);
 
+  @Query("SELECT si.* FROM shipping_instrution si "
+    + "JOIN transport_document td ON (si.id = td.shipping_instruction_id) "
+    + "WHERE td.transport_document_reference = :transportDocumentReference"
+  )
+  Mono<ShippingInstruction> findByTransportDocumentReference(String transportDocumentReference);
+
   Flux<ShippingInstruction> findShippingInstructionByShippingInstructionReferenceAndDocumentStatus(
       String id, ShipmentEventTypeCode documentStatus);
 }

--- a/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionServiceImpl.java
@@ -26,10 +26,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -121,7 +118,25 @@ public class ShippingInstructionServiceImpl implements ShippingInstructionServic
     shippingInstruction.setShippingInstructionCreatedDateTime(now);
     shippingInstruction.setShippingInstructionUpdatedDateTime(now);
 
-    return validateDocumentStatusOnBooking(shippingInstructionTO)
+    return Mono.justOrEmpty(shippingInstructionTO.getAmendmentToTransportDocument())
+        .flatMap(tdReference ->
+          // If this is an amendment, verify that the TD exist and is in the correct status.
+          shippingInstructionRepository.findByTransportDocumentReference(tdReference)
+          .switchIfEmpty(Mono.error(ConcreteRequestErrorMessageException.invalidParameter(
+            "Shipping Instruction",
+            "amendmentToTransportDocument",
+            "Unknown Transport Document Reference: " + tdReference
+          ))).flatMap(siForTD -> {
+              if (siForTD.getDocumentStatus() != ShipmentEventTypeCode.ISSU) {
+                return Mono.error(ConcreteRequestErrorMessageException.invalidParameter(
+                  "Shipping Instruction",
+                  "amendmentToTransportDocument",
+                    "The referenced transport document (" + tdReference + ") must be in state ISSU, but had state: " + siForTD.getDocumentStatus()
+                  ));
+              }
+              return Mono.empty();
+          })
+        ).then(validateDocumentStatusOnBooking(shippingInstructionTO))
         .flatMap(ignored -> shippingInstructionRepository.save(shippingInstruction))
         .flatMap(si -> createShipmentEvent(si).thenReturn(si))
         .flatMap(
@@ -185,7 +200,17 @@ public class ShippingInstructionServiceImpl implements ShippingInstructionServic
                 ConcreteRequestErrorMessageException.invalidParameter(
                     "No Shipping Instruction found with ID: " + shippingInstructionReference)))
         .flatMap(checkUpdateShippingInstructionStatus)
-        .flatMap(si -> createShipmentEvent(si).thenReturn(si))
+        .flatMap(si -> {
+          // We do not allow the amendmentToTransportDocument to change in PUT. It is not required and a lot of hassle.
+          if (!Objects.equals(si.getAmendmentToTransportDocument(), shippingInstructionRequest.getAmendmentToTransportDocument())) {
+            return Mono.error(ConcreteRequestErrorMessageException.invalidParameter(
+              "Shipping Instruction",
+              "amendmentToTransportDocument",
+              "The update would change the value of amendmentToTransportDocument, which is not allowed."
+            ));
+          }
+          return Mono.just(si);
+        }).flatMap(si -> createShipmentEvent(si).thenReturn(si))
         .flatMap(
             si -> {
               shippingInstructionRequest.setShippingInstructionReference(

--- a/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/ShippingInstructionServiceImpl.java
@@ -341,8 +341,7 @@ public class ShippingInstructionServiceImpl implements ShippingInstructionServic
     Supplier<Stream<ShipmentEquipmentTO>> shipmentEquipmentTOStream =
         () ->
             Stream.ofNullable(shippingInstructionTO.getShipmentEquipments())
-                .flatMap(shipmentEquipmentTOS -> Stream.ofNullable(shipmentEquipmentTOS.stream()))
-                .flatMap(Function.identity());
+                .flatMap(Collection::stream);
 
     // Check if carrierBooking reference is only set on one place,
     // either shipping instruction or cargo item


### PR DESCRIPTION
Amendments to TDs that are `ISSU` are done by posting a new SI with
the desired content and a TD reference in the
`admendmentToTransportDocument` field. For now, the state flow for
these SIs are the same as regular SIs at least until the `DRFT` state
(and probably also the `APPR` state except charges might occur but we
do not do these).

To keep things simple, we do not allow the
`admendmentToTransportDocument` field to be changed in PUT.
