### PR TITLE
Fix race-condition when storing cargo items

### DIFF
--- a/src/main/java/org/dcsa/ebl/service/TransportDocumentService.java
+++ b/src/main/java/org/dcsa/ebl/service/TransportDocumentService.java
@@ -10,7 +10,6 @@ import java.util.UUID;
 
 public interface TransportDocumentService
     extends AsymmetricQueryService<TransportDocument, TransportDocumentSummary, UUID> {
-  Mono<TransportDocumentTO> findById(String transportDocumentReference);
 
   Mono<TransportDocumentTO> findByTransportDocumentReference(String transportDocumentReference);
 

--- a/src/main/java/org/dcsa/ebl/service/impl/TransportDocumentServiceImpl.java
+++ b/src/main/java/org/dcsa/ebl/service/impl/TransportDocumentServiceImpl.java
@@ -28,7 +28,6 @@ import org.dcsa.skernel.model.enums.CarrierCodeListProvider;
 import org.dcsa.skernel.repositority.CarrierRepository;
 import org.dcsa.skernel.service.LocationService;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -61,13 +60,6 @@ public class TransportDocumentServiceImpl
   public TransportDocumentRepository getRepository() {
     return transportDocumentRepository;
   }
-
-  @Transactional
-  @Override
-  public Mono<TransportDocumentTO> findById(String transportDocumentReference) {
-    return Mono.empty();
-  }
-
   @Override
   protected Mono<TransportDocumentSummary> mapDM2TO(TransportDocument transportDocument) {
     TransportDocumentSummary transportDocumentSummary =


### PR DESCRIPTION
Ensure that UtilizedTransportEquipments have been persisted before
attempting to store cargo items. This avoids a constraint validation
error from the database when the race is "won" (or "lost" depending on
your perspective).

Signed-off-by: Niels Thykier <nt@asseco.dk>