### PR TITLE
DDT-1037: Split TC ID and TC Reference

### DIFF
--- a/src/test/java/ebl/v2/ShipmentEventIT.java
+++ b/src/test/java/ebl/v2/ShipmentEventIT.java
@@ -227,10 +227,10 @@ class ShipmentEventIT {
       .assertThat()
       .statusCode(200)
       .contentType(ContentType.JSON)
-      // The test data includes 1 shipment event for this case. Given the narrow date range, it seems acceptable to
+      // The test data includes 2 shipment events for this case. Given the narrow date range, it seems acceptable to
       // validate an exact match.  Note the strict match is used to validate that the TZ conversion works correctly
       // when filtering
-      .body("size()", equalTo(1))
+      .body("size()", equalTo(2))
       .body("eventType", everyItem(equalTo("SHIPMENT")))
       .body("eventClassifierCode", everyItem(equalTo("ACT")))
       .body("documentTypeCode", everyItem(anyOf(equalTo("SHI"), equalTo("TRD"))))


### PR DESCRIPTION
Some SQL update in the past apparently changes the number of results
for one of the endpoints. I have added that change to this commit for
sake of simplicity.

Signed-off-by: Niels Thykier <nt@asseco.dk>